### PR TITLE
Out-of-bounds memory access in `crypto_sign_open()`

### DIFF
--- a/src/packing.c
+++ b/src/packing.c
@@ -255,6 +255,8 @@ int unpack_public_key(
     int64_t  *h)
 {
     param = pq_get_param_set_by_id(blob[0]);
+    if (param == NULL)
+        return -1;
     string_to_rndpoly (param->N, h, blob+1);
     return 0;
 }

--- a/src/sign.c
+++ b/src/sign.c
@@ -132,7 +132,8 @@ int crypto_sign_open(
 
     unpack_public_key(pk, param,  h);
 
-    unpack_public_key(sm, param,  sig);
+    if (unpack_public_key(sm, param,  sig)!=0)
+        return -1;
 
     if(verify(sig, m, *mlen, h,buf,param)!=0)
     {


### PR DESCRIPTION
I do not know if `crypto_sign_open()` is expected to handle malformed input, yet it should not cause a large write at a null pointer if fed with a misaligned message
